### PR TITLE
Fix example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ editor.read(filePath)
     matter.data = data;
   })
   .show()
-  .save(destPath, {postfix:'new'});
+  .save(destPath, {postfix:'new'}, (err) => {
+      if (err) {
+        console.log('could not save', err);
+      }
+  });
 ```
 
 ## front-matter-editor methods


### PR DESCRIPTION
Add callback to example call of `.save()`

This will improve errors like the ones mentioned in
https://github.com/saltfactory/front-matter-editor/issues/1