### PR TITLE
Add filesystem info param to change callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ function updateHandler(data, matter) {
 editor.read(filePath).data(updateHandler);
 ```
 
+You can use the optional third parameter `fileSystemInfo` to access information about the file itself:
+
+```
+let extend = require('util')._extend;
+
+function updateHandler(data, matter, fileSystemInfo) {
+  const d = fileSystemInfo.status.mtime;
+  data.last_updated = [d.getFullYear(), d.getMonth()+1, d.getDate()].join('-');
+  matter.data = data;
+}
+
+editor.read(filePath).data(updateHandler);
+```
+
 ## .content()
 This method update content in file.
 ```
@@ -83,6 +97,8 @@ function updateHandler(content, matter) {
 
 editor.read(filePath).content(updateHandler);
 ```
+
+This method also supports the optional third parameter `fileSystemInfo` for the callback.
 
 ## .save(destDirPath, options, callback)
 

--- a/index.js
+++ b/index.js
@@ -29,18 +29,18 @@ class FrontMatterService {
   }
 
   extend(func) {
-    func(this.matter.data, this.matter.content, this.matter);
+    func(this.matter.data, this.matter.content, this.matter, this.fileSystemInfo);
     return this;
   }
 
   data(func) {
     // this.matter = extend(this.matter, obj);
-    func(this.matter.data, this.matter);
+    func(this.matter.data, this.matter, this.fileSystemInfo);
     return this;
   }
 
   content(func) {
-    func(this.matter.content, this.matter);
+    func(this.matter.content, this.matter, this.fileSystemInfo);
     return this;
   }
 
@@ -79,4 +79,3 @@ module.exports = new FrontMatterService();
 // module.exports.prototype.show = function(){
 //   console.log(this.)
 // }
-


### PR DESCRIPTION
Sometimes, you need information about the file (e.g. its modification
date, its path, its extension or its filename) to produce new front
matter or content. This patch can help with that.